### PR TITLE
Fix line endings in unit tests to allow tests to pass on windows systems

### DIFF
--- a/src/datatests/pose.rs
+++ b/src/datatests/pose.rs
@@ -50,7 +50,7 @@ mod tests {
         assert_eq!(6, header.len());
         assert_eq!("/meow", header.get("topic").unwrap());
         assert_eq!("0", header.get("tcp_nodelay").unwrap());
-        assert_eq!(include_str!("pose_message_definition.txt"),
+        assert_eq!(&include_str!("pose_message_definition.txt").replace("\r", ""),
                    header.get("message_definition").unwrap());
         assert_eq!("geometry_msgs/Pose", header.get("type").unwrap());
         assert_eq!("e45d45a5a1ce597b249e23fb30fc871f",
@@ -65,7 +65,7 @@ mod tests {
         assert_eq!(6, header.len());
         assert_eq!("/meow", header.get("topic").unwrap());
         assert_eq!("1", header.get("latching").unwrap());
-        assert_eq!(include_str!("pose_message_definition.txt"),
+        assert_eq!(&include_str!("pose_message_definition.txt").replace("\r", ""),
                    header.get("message_definition").unwrap());
         assert_eq!("geometry_msgs/Pose", header.get("type").unwrap());
         assert_eq!("e45d45a5a1ce597b249e23fb30fc871f",

--- a/src/datatests/pose_array.rs
+++ b/src/datatests/pose_array.rs
@@ -85,7 +85,7 @@ mod tests {
         assert_eq!(6, header.len());
         assert_eq!("/xax", header.get("topic").unwrap());
         assert_eq!("0", header.get("tcp_nodelay").unwrap());
-        assert_eq!(include_str!("pose_array_message_definition.txt"),
+        assert_eq!(&include_str!("pose_array_message_definition.txt").replace("\r", ""),
                    header.get("message_definition").unwrap());
         assert_eq!("geometry_msgs/PoseArray", header.get("type").unwrap());
         assert_eq!("916c28c5764443f268b296bb671b9d97",
@@ -101,7 +101,7 @@ mod tests {
         assert_eq!(6, header.len());
         assert_eq!("/xax", header.get("topic").unwrap());
         assert_eq!("1", header.get("latching").unwrap());
-        assert_eq!(include_str!("pose_array_message_definition.txt"),
+        assert_eq!(&include_str!("pose_array_message_definition.txt").replace("\r", ""),
                    header.get("message_definition").unwrap());
         assert_eq!("geometry_msgs/PoseArray", header.get("type").unwrap());
         assert_eq!("916c28c5764443f268b296bb671b9d97",

--- a/src/datatests/pose_with_covariance.rs
+++ b/src/datatests/pose_with_covariance.rs
@@ -59,7 +59,7 @@ mod tests {
         assert_eq!(6, header.len());
         assert_eq!("/woah", header.get("topic").unwrap());
         assert_eq!("0", header.get("tcp_nodelay").unwrap());
-        assert_eq!(include_str!("pose_with_covariance_message_definition.txt"),
+        assert_eq!(&include_str!("pose_with_covariance_message_definition.txt").replace("\r", ""),
                    header.get("message_definition").unwrap());
         assert_eq!("geometry_msgs/PoseWithCovariance",
                    header.get("type").unwrap());
@@ -77,7 +77,7 @@ mod tests {
         assert_eq!(6, header.len());
         assert_eq!("/woah", header.get("topic").unwrap());
         assert_eq!("1", header.get("latching").unwrap());
-        assert_eq!(include_str!("pose_with_covariance_message_definition.txt"),
+        assert_eq!(&include_str!("pose_with_covariance_message_definition.txt").replace("\r", ""),
                    header.get("message_definition").unwrap());
         assert_eq!("geometry_msgs/PoseWithCovariance",
                    header.get("type").unwrap());


### PR DESCRIPTION
To reproduce issue:

- Use git to clone repo in a windows environment
- Git default settings automatically checkout text files with CRLF endings and commits them with LF endings
- Run `cargo test` in windows and tests will fail due to line ending mismatch

With changes in this MR tests will pass successfully in both windows and linux environments