### PR TITLE
Update error chain dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ repository = "adnanademovic/serde_rosmsg"
 
 [dependencies]
 byteorder = "1.0.0"
-error-chain = "0.10.0"
+error-chain = "0.12"
 serde = "1.0.2"
 serde_derive = "1.0.2"


### PR DESCRIPTION
Building this crate on modern rustc (1.79) produces the following errors:

```
warning: use of deprecated method `std::error::Error::cause`: replaced by Error::source, which can support downcasting
  --> src\error.rs:1:1
   |
1  | / error_chain! {
2  | |     foreign_links {
3  | |         Io(::std::io::Error);
4  | |     }
...  |
46 | |     }
47 | | }
   | |_^
   |
   = note: this warning originates in the macro `error_chain_processed` which comes from the expansion of the macro `error_chain` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Upgrading to the latest error-chain version fixes this warning. This may affect the MSRV of this crate, but is probably worth doing.