### PR TITLE
97% Faster Image Parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,18 @@ byteorder = "1.0.0"
 error-chain = "0.10.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
+
+[dev-dependencies]
+# Used as benchmarking framework
+# Run with `cargo bench --bench image_bench`
+criterion = { version = "0.5", features = ["html_reports"] }
+# Used to generate flamegraphs for profiling
+# Run with `cargo bench --bench image_bench -- --profile-time 5`
+# Files will be in target/criterion/<bench_name>/profile/flamegraph.svg
+pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
+# Optimization demonstrated in benchmarks
+serde_bytes = "0.11"
+
+[[bench]]
+name = "image_bench"
+harness = false

--- a/benches/image_bench.rs
+++ b/benches/image_bench.rs
@@ -1,0 +1,143 @@
+// TODO unclear why we need these extern crates here?
+extern crate criterion;
+extern crate pprof;
+extern crate serde;
+extern crate serde_rosmsg;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+
+const IMAGE_DATA: &[u8] = include_bytes!("../src/datatests/sensor_msgs_image_1080p.bin");
+
+use pprof::criterion::{Output, PProfProfiler};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+pub struct Header {
+    pub seq: u32,
+    pub stamp: Time,
+    pub frame_id: String,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+pub struct Time {
+    pub secs: u32,
+    pub nsecs: u32,
+}
+
+// Basic Image Representation
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+pub struct VecImage {
+    pub header: Header,
+    pub height: u32,
+    pub width: u32,
+    pub encoding: String,
+    pub is_bigendian: u8,
+    pub step: u32,
+    pub data: Vec<u8>,
+}
+
+// Includes serde_bytes optimization
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+pub struct VecBytesImage {
+    pub header: Header,
+    pub height: u32,
+    pub width: u32,
+    pub encoding: String,
+    pub is_bigendian: u8,
+    pub step: u32,
+    // serde_bytes optimization here makes deserialization of an image ~97% faster
+    // Without it deserializing a 1080p color image took ~22.2ms on a Ryzen 3950x
+    // With it that drops to 520us on the same system
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
+}
+
+// Below two options not currently supported
+// // No serde_bytes optimization referenced data instead of copying it
+// // Note: Deserializer is not really setup to take advantage of this yet
+// #[derive(Deserialize, Serialize, PartialEq, Debug)]
+// pub struct RefImage<'a> {
+//     pub header: Header,
+//     pub height: u32,
+//     pub width: u32,
+//     pub encoding: String,
+//     pub is_bigendian: u8,
+//     pub step: u32,
+//     pub data: &'a [u8],
+// }
+
+// // With serde_bytes optimization, on referenced data
+// #[derive(Deserialize, Serialize, PartialEq, Debug)]
+// pub struct RefBytesImage<'a> {
+//     pub header: Header,
+//     pub height: u32,
+//     pub width: u32,
+//     pub encoding: String,
+//     pub is_bigendian: u8,
+//     pub step: u32,
+//     #[serde(with = "serde_bytes")]
+//     pub data: &'a [u8],
+// }
+
+// An alternate expression option that also works
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+pub struct SharedImage {
+    pub header: Header,
+    pub height: u32,
+    pub width: u32,
+    pub encoding: String,
+    pub is_bigendian: u8,
+    pub step: u32,
+    pub data: Box<[u8]>,
+}
+
+#[inline]
+fn parse_vec_image() {
+    let image: VecImage = serde_rosmsg::from_slice(IMAGE_DATA).unwrap();
+    black_box(image);
+}
+
+#[inline]
+fn parse_vec_bytes_image() {
+    let image: VecBytesImage = serde_rosmsg::from_slice(IMAGE_DATA).unwrap();
+    black_box(image);
+}
+
+#[inline]
+fn parse_shared_image() {
+    let image: SharedImage = serde_rosmsg::from_slice(IMAGE_DATA).unwrap();
+    black_box(image);
+}
+
+// Not supported yet
+// #[inline]
+// fn parse_ref_image() {
+//     let image: RefImage = serde_rosmsg::from_slice(IMAGE_DATA).unwrap();
+//     black_box(image);
+// }
+
+// #[inline]
+// fn parse_ref_bytes_image() {
+//     let image: RefBytesImage = serde_rosmsg::from_slice(IMAGE_DATA).unwrap();
+//     black_box(image);
+// }
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("parse_vec_image", |b| b.iter(|| parse_vec_image()));
+    c.bench_function("parse_vec_bytes_image", |b| {
+        b.iter(|| parse_vec_bytes_image())
+    });
+    // c.bench_function("parse_ref_image", |b| b.iter(|| parse_ref_image()));
+    // c.bench_function("parse_ref_bytes_image", |b| {
+    //     b.iter(|| parse_ref_bytes_image())
+    // });
+    c.bench_function("parse_shared_image", |b| b.iter(|| parse_shared_image()));
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+);
+criterion_main!(benches);

--- a/src/datatests/mod.rs
+++ b/src/datatests/mod.rs
@@ -7,3 +7,4 @@ mod string;
 mod pose;
 mod pose_with_covariance;
 mod pose_array;
+mod sensor_msgs_image;

--- a/src/datatests/sensor_msgs_image.rs
+++ b/src/datatests/sensor_msgs_image.rs
@@ -1,0 +1,78 @@
+//! Perform tests with sensor_msgs/Image
+
+#[cfg(test)]
+mod tests {
+    use from_slice;
+
+    #[derive(Deserialize, Serialize, PartialEq, Debug)]
+    pub struct Image {
+        pub header: Header,
+        pub height: u32,
+        pub width: u32,
+        pub encoding: String,
+        pub is_bigendian: u8,
+        pub step: u32,
+        pub data: Vec<u8>,
+    }
+
+    // Not supported at the moment
+    // #[derive(Deserialize, Serialize, PartialEq, Debug)]
+    // pub struct RefImage<'a> {
+    //     pub header: Header,
+    //     pub height: u32,
+    //     pub width: u32,
+    //     pub encoding: String,
+    //     pub is_bigendian: u8,
+    //     pub step: u32,
+    //     pub data: &'a [u8],
+    // }
+
+    #[derive(Deserialize, Serialize, PartialEq, Debug)]
+    pub struct SharedImage {
+        pub header: Header,
+        pub height: u32,
+        pub width: u32,
+        pub encoding: String,
+        pub is_bigendian: u8,
+        pub step: u32,
+        pub data: Box<[u8]>,
+    }
+
+    #[derive(Deserialize, Serialize, PartialEq, Debug)]
+    pub struct Header {
+        pub seq: u32,
+        pub stamp: Time,
+        pub frame_id: String,
+    }
+
+    #[derive(Deserialize, Serialize, PartialEq, Debug)]
+    pub struct Time {
+        pub secs: u32,
+        pub nsecs: u32,
+    }
+
+    #[test]
+    fn reads_message() {
+        let expectation = Image {
+            header: Header {
+                stamp: Time { secs: 0, nsecs: 0 },
+                frame_id: "test".to_string(),
+                seq: 0,
+            },
+            height: 1080,
+            width: 1920,
+            encoding: "bgr8".to_string(),
+            is_bigendian: false as u8,
+            step: 5760,
+            data: vec![0; 1080 * 1920 * 3],
+        };
+        let bytes = include_bytes!("sensor_msgs_image_1080p.bin");
+        let msg: Image = from_slice(bytes).unwrap();
+        assert_eq!(expectation, msg);
+        // Prove that deserialization works with different representations of Image
+        // Assume that data is same
+        let _msg: SharedImage = from_slice(bytes).unwrap();
+        // let _msg: RefImage = from_slice(bytes).unwrap();
+    }
+
+}

--- a/src/datatests/sensor_msgs_image.txt
+++ b/src/datatests/sensor_msgs_image.txt
@@ -1,0 +1,43 @@
+# This message contains an uncompressed image
+# (0, 0) is at top-left corner of image
+#
+
+Header header        # Header timestamp should be acquisition time of image
+                     # Header frame_id should be optical frame of camera
+                     # origin of frame should be optical center of camera
+                     # +x should point to the right in the image
+                     # +y should point down in the image
+                     # +z should point into to plane of the image
+                     # If the frame_id here and the frame_id of the CameraInfo
+                     # message associated with the image conflict
+                     # the behavior is undefined
+
+uint32 height         # image height, that is, number of rows
+uint32 width          # image width, that is, number of columns
+
+# The legal values for encoding are in file src/image_encodings.cpp
+# If you want to standardize a new string format, join
+# ros-users@lists.sourceforge.net and send an email proposing a new encoding.
+
+string encoding       # Encoding of pixels -- channel meaning, ordering, size
+                      # taken from the list of strings in include/sensor_msgs/image_encodings.h
+
+uint8 is_bigendian    # is this data bigendian?
+uint32 step           # Full row length in bytes
+uint8[] data          # actual matrix data, size is (step * rows)
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id


### PR DESCRIPTION
While profiling an application using `roslibrust` that relies on this crate for serialization logic. I discovered that the application was taking a substantial amount of time to parse an image message using serde_rosmsg.

Diving in I discovered that even with an optimized release build, the code was ending up walking every byte in the image resulting in ~2.3 million function calls to parse a 1080p image.

After a decent amount of fiddling and trying different solutions, I discovered that https://docs.rs/serde_bytes/latest/serde_bytes/ could be used to cue serde into calling deserialize_byte_buf for the case of Deserializing into a Vec<u8> and that by specializing that  case to bulk deserialize the entire array, we could turn an iteration over every byte in an image to effectively a bulk memcpy.

Comparing the code that hits the optimization to the code that doesn't:
```
parse_vec_image         time:   [22.450 ms 22.543 ms 22.643 ms]
                        change: [-2.4723% -2.0143% -1.5825%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high severe

parse_vec_bytes_image   time:   [527.16 µs 528.77 µs 530.31 µs]
                        change: [-4.6984% -3.1317% -1.7029%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
  ```
  
We go from 22.5ms to deserialize a 1080p image to 530us :partying_face: :tada:.
  
This is a relatively niche optimization as it only applies to uint8[] to Vec<u8> conversions, but as this is the underlying buffer type or sensor_msgs/Image and sensor_msgs/PointCloud2, this will mean a massive speed up for some common ROS use cases.

I've included the benchmarking code in this MR in case that is useful, but would be happy to prepare a version with only the minimal set of changes.

 For reference here is the flamegraph from the version that misses this optimization: 
![flamegraph](https://github.com/user-attachments/assets/041765c3-af39-4a04-b394-b5de55dafcc8)
You can see bulk of time being spent in VecVisitor<T> individually accessing each element.

And here is with the optimization:
![flamegraph](https://github.com/user-attachments/assets/de4746d6-d162-4576-8e46-201524bedf1b)
You can see that bulk of time is spent in allocation, and AVX copies. In this version ~50% of time is being spent in allocation, so the only remaining optimization is to get deserialization to `&'de [u8]` working.
